### PR TITLE
feat(core): Compatibility with Keptn 0.9/0.10 for triggering sequences/events (#41)

### DIFF
--- a/SendKeptnEventTask/index.ts
+++ b/SendKeptnEventTask/index.ts
@@ -390,7 +390,7 @@ async function triggerDelivery(input:Params, httpClient:AxiosInstance){
 		url: input.keptnApiEndpoint + '/v1/event',
 		headers: {'x-token': input.keptnApiToken},
 		data: {
-			type: 'sh.keptn.events.' + input.stage + '.' + input.deliveryParams?.sequence + '.triggered',
+			type: 'sh.keptn.event.' + input.stage + '.' + input.deliveryParams?.sequence + '.triggered',
 			source: 'azure-devops-plugin',
 			specversion: '1.0',
 			data: {
@@ -442,7 +442,7 @@ async function triggerGeneric(input:Params, httpClient:AxiosInstance){
 		url: input.keptnApiEndpoint + '/v1/event',
 		headers: {'x-token': input.keptnApiToken},
 		data: {
-			type: 'sh.keptn.events.' + input.stage + '.' + (input.deliveryParams!=undefined?input.deliveryParams.sequence:'delivery') + '.triggered',
+			type: 'sh.keptn.event.' + input.stage + '.' + (input.deliveryParams!=undefined?input.deliveryParams.sequence:'delivery') + '.triggered',
 			source: 'azure-devops-plugin',
 			specversion: '1.0'
 		}


### PR DESCRIPTION
# This PR

- changes Keptn CloudEvent types from `events` to `event` where appropriate (I did not touch the pre-0.8 functions and alike)
 
Fixes #41 

