### PR TITLE
fix(core): Better http status code checks (#36)

### DIFF
--- a/AddKeptnResourceTask/index.ts
+++ b/AddKeptnResourceTask/index.ts
@@ -199,6 +199,6 @@ if (input !== undefined){
 	run(input).then(result => {
     	console.log(result);
 	}).catch(err => {
-		console.error(err);
+		tl.setResult(tl.TaskResult.Failed, `${err}`);
 	});
 }

--- a/PrepareKeptnEnvTask/index.ts
+++ b/PrepareKeptnEnvTask/index.ts
@@ -413,6 +413,6 @@ if (input !== undefined){
 	run(input).then(result => {
     	console.log(result);
 	}).catch(err => {
-		console.error(err);
+		tl.setResult(tl.TaskResult.Failed, `${err}`);
 	});
 }

--- a/PrepareKeptnEnvTask/tests/_suite.ts
+++ b/PrepareKeptnEnvTask/tests/_suite.ts
@@ -11,6 +11,23 @@ describe('Prepare Keptn Env task tests', function () {
     after(() => {
 
     });
+
+	it('must fail creating a project when projectname is invalid', function(done: MochaDone) {
+		this.timeout(10000);
+
+		let tp = path.join(__dirname, 'createproject_invalid.js');
+	    let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+	
+		tr.run();
+		
+		console.log(tr.succeeded);
+		console.log(tr.stdout);
+		console.log(tr.stderr);
+
+	    assert.equal(tr.succeeded, false, 'should not have succeeded');
+
+		done();
+	});
 	
 	it('must create a project', function(done: MochaDone) {
 		this.timeout(10000);

--- a/PrepareKeptnEnvTask/tests/createproject_invalid.ts
+++ b/PrepareKeptnEnvTask/tests/createproject_invalid.ts
@@ -1,0 +1,17 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs from 'fs';
+
+let taskPath = path.join(__dirname, '..', 'index.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+tmr.setInput('project', 'new-test-project2>$');
+tmr.setInput('service', 'test-service');
+tmr.setInput('stage', 'hardening');
+tmr.setInput('keptnApiEndpoint', '1234567');
+let keptnFile = fs.readFileSync(require('os').homedir() + '/.keptn/.keptn','utf8');
+tmr.registerMockExport("getEndpointUrl", function(){return keptnFile.split('\n')[0]});
+tmr.registerMockExport("getEndpointAuthorizationParameter", function(){return keptnFile.split('\n')[1]});
+tmr.setInput('autoCreate', 'true');
+
+tmr.run();

--- a/WaitForKeptnEventTask/index.ts
+++ b/WaitForKeptnEventTask/index.ts
@@ -362,6 +362,6 @@ if (input !== undefined){
 	run(input).then(result => {
     	console.log(result);
 	}).catch(err => {
-		console.error(err);
+		tl.setResult(tl.TaskResult.Failed, `${err}`);
 	});
 }


### PR DESCRIPTION
# This PR

- Handles errors in tasks by using taskLib.setResult which will fail the pipeline/task properly 

Fixes #36