### PR TITLE
chore: update AZDO dependencies, add helper function to run tests

### DIFF
--- a/AddKeptnResourceTask/package.json
+++ b/AddKeptnResourceTask/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^2.9.3"
+    "azure-pipelines-task-lib": "^3.1.10"
   }
 }

--- a/PrepareKeptnEnvTask/package.json
+++ b/PrepareKeptnEnvTask/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^2.9.3"
+    "azure-pipelines-task-lib": "^3.1.10"
   }
 }

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -14,31 +14,33 @@ In the main directory run
 npm install
 ```
 
-Go to each Task directory and run
+Then run
 ```
-npm install
+npm run install-all
 ```
 
-## Build
+which will go to each task directory and install dependencies there.
+
+## Clean, Build, Test (CBT)
 
 In the main directory, run
 ```
+npm run cbt
+```
+which will clean the repo, build (transpile) the code, and test it. Alternatively, you can those steps on your own:
+
+```
+npm run clean
+
 npm run build
-```
 
-## Test
-
-**Important**: You need to run `npm run build` before you test the package!
-
-In the main directory, run
-```
 npm run test-prep
 npm run test-send
 npm run test-wait
 npm run test-addr
 ```
 
-## Test the extension
+# Test the extension
 
 ## Create Private Dev VSIX Package
 

--- a/SendKeptnEventTask/package.json
+++ b/SendKeptnEventTask/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^2.9.3",
+    "azure-pipelines-task-lib": "^3.1.10",
     "moment-timezone": "^0.5.28"
   }
 }

--- a/WaitForKeptnEventTask/package.json
+++ b/WaitForKeptnEventTask/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "axios": "^0.21.1",
-    "azure-pipelines-task-lib": "^2.9.3",
+    "azure-pipelines-task-lib": "^3.1.10",
     "moment-timezone": "^0.5.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "test-send": "mocha SendKeptnEventTask/tests/_suite.js",
     "test-wait": "mocha WaitForKeptnEventTask/tests/_suite.js",
     "test-addr": "mocha AddKeptnResourceTask/tests/_suite.js",
+    "install-all": "cd PrepareKeptnEnvTask && npm install && cd ../SendKeptnEventTask && npm install && cd ../WaitForKeptnEventTask && npm install && cd ../AddKeptnResourceTask && npm install && cd ..",
     "cbt": "npm run clean && npm run build && npm run test-prep && npm run test-send && npm run test-wait && npm run test-addr",
     "package-dev": "gulp --dev && tfx extension create --manifest-globs vss-extension.json",
     "package": "gulp --public && tfx extension create --manifest-globs vss-extension.json"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/keptn-contrib/azureveops-keptn-plugin"
+    "url": "https://github.com/keptn-sandbox/keptn-azure-devops-extension"
   },
   "author": "Bert Van der Heyden (realdolmen.com)",
   "devDependencies": {
@@ -34,7 +35,7 @@
     "yargs": "^15.4.1"
   },
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.9.3",
+    "azure-pipelines-task-lib": "^3.1.10",
     "moment-timezone": "^0.5.28",
     "axios": "^0.21.1"
   }


### PR DESCRIPTION
I noticed that testing (npm run test...) didn't work locally, and the problem was that the azure devops pipeline library needed to be updated.

In addition, I updated docs and added helper commands to package.json.