### PR TITLE
build: remove package.json and node_modules from tasks directories

### DIFF
--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -26,7 +26,7 @@ runs:
       run: npm install typescript@4.0.2
     - name: Install Dependencies
       shell: bash
-      run: npm install && npm run install-all
+      run: npm install
     - name: Build
       shell: bash
       run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 package-lock.json
 .publish.sh
 *.vsix
+dist/

--- a/AddKeptnResourceTask/package.json
+++ b/AddKeptnResourceTask/package.json
@@ -1,6 +1,0 @@
-{
-  "dependencies": {
-    "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^3.1.10"
-  }
-}

--- a/KeptnCLITask/package.json
+++ b/KeptnCLITask/package.json
@@ -1,6 +1,0 @@
-{
-  "dependencies": {
-    "axios": "^0.21.1",
-    "azure-pipelines-task-lib": "^2.9.3"
-  }
-}

--- a/PrepareKeptnEnvTask/package.json
+++ b/PrepareKeptnEnvTask/package.json
@@ -1,6 +1,0 @@
-{
-  "dependencies": {
-    "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^3.1.10"
-  }
-}

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -21,13 +21,6 @@ In the main directory run
 npm install
 ```
 
-Then run
-```
-npm run install-all
-```
-
-which will go to each task directory and install dependencies there.
-
 ## Clean, Build, Test (CBT)
 
 **Note:** at the time of writing, existing tests are flaky, please proceed with caution

--- a/SendKeptnEventTask/package.json
+++ b/SendKeptnEventTask/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "axios": ">=0.21.1",
-    "azure-pipelines-task-lib": "^3.1.10",
-    "moment-timezone": "^0.5.28"
-  }
-}

--- a/WaitForKeptnEventTask/package.json
+++ b/WaitForKeptnEventTask/package.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "axios": "^0.21.1",
-    "azure-pipelines-task-lib": "^3.1.10",
-    "moment-timezone": "^0.5.28"
-  }
-}

--- a/manifest.js
+++ b/manifest.js
@@ -100,14 +100,26 @@ module.exports = (env) => {
 			"path": "PrepareKeptnEnvTask"
 		  },
 		  {
+			"path": "dist", "packagePath": "/PrepareKeptnEnvTask"
+		  },
+		  {
 			"path": "SendKeptnEventTask"
+		  },
+		  {
+			"path": "dist", "packagePath": "/SendKeptnEventTask"
 		  },
 		  {
 			"path": "WaitForKeptnEventTask"
 		  },
 		  {
+			"path": "dist", "packagePath": "/WaitForKeptnEventTask"
+		  },
+		  {
 			"path": "AddKeptnResourceTask"
-		  }
+		  },
+		  {
+			"path": "dist", "packagePath": "/AddKeptnResourceTask"
+		  },
 		]
 	  }
 

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "version": "1.0.0",
   "description": "Integration of Keptn within your build.",
   "scripts": {
-    "clean": "rimraf ./*.vsix",
+    "clean": "rimraf ./*.vsix ./dist",
     "build": "tsc -p .",
     "test-prep": "mocha PrepareKeptnEnvTask/tests/_suite.js",
     "test-send": "mocha SendKeptnEventTask/tests/_suite.js",
     "test-wait": "mocha WaitForKeptnEventTask/tests/_suite.js",
     "test-addr": "mocha AddKeptnResourceTask/tests/_suite.js",
     "test-all": "npm run test-prep && npm run test-send && npm run test-wait && npm run test-addr",
-    "install-all": "cd PrepareKeptnEnvTask && npm install && cd ../SendKeptnEventTask && npm install && cd ../WaitForKeptnEventTask && npm install && cd ../AddKeptnResourceTask && npm install && cd ..",
     "cbt": "npm run clean && npm run build && npm run test-all",
-    "package-dev": "tfx extension create --manifest-js manifest.js --env mode=development",
-    "package": "tfx extension create --manifest-js manifest.js",
-    "publish-dev": "tfx extension publish -t ${AZDO_PUBTOKEN} --manifest-js manifest.js --env mode=development",
-    "publish": "tfx extension publish -t ${AZDO_PUBTOKEN} --manifest-js manifest.js"
+    "package-prod-deps": "rimraf ./dist/node_modules/ ./dist/package.json && cp ./package.json ./dist && npm install --production --prefix ./dist",
+    "package-dev": "npm run package-prod-deps && tfx extension create --manifest-js manifest.js --env mode=development",
+    "package": "npm run package-prod-deps && tfx extension create --manifest-js manifest.js",
+    "publish-dev": "npm run package-prod-deps && tfx extension publish -t ${AZDO_PUBTOKEN} --manifest-js manifest.js --env mode=development",
+    "publish": "npm run package-prod-deps && tfx extension publish -t ${AZDO_PUBTOKEN} --manifest-js manifest.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove duplication of dependencies in each task by coalescing all task
dependencies in the root directory.
IDEs and node work fine with this approach but running on Azure DevOps
agents requires each task to package its own dependencies.
To work around this the same package.json and node_modules is copied in
each task directory when packaging

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>