### PR TITLE
fix: update WaitForKeptnEvent package paths

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -146,13 +146,13 @@ module.exports = (env) => {
   addTaskToContribution(
     manifest.contributions,
     "waitfor-keptn-event",
-    "WaitForEventTask",
+    "WaitForKeptnEventTask",
     "Wait for a Keptn event"
   );
   addPathToFileContributions(
     manifest.files,
     "dist",
-    "WaitForEventTask/WaitForEventTaskV2"
+    "WaitForKeptnEventTask/WaitForKeptnEventTaskV2"
   );
 
   return manifest;


### PR DESCRIPTION
This PR fixes the paths for packaging the extensions. In PR #77 the paths for WaitKeptnEventTask were incorrect.

Signed-off-by: Paolo Chila <paolo.chila@dynatrace.com>