### PR TITLE
ci: add release automation

### DIFF
--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -2,10 +2,6 @@
 name: 'Unit Tests'
 description: 'Run unit tests using Node.js'
 inputs:
-  NODE_VERSION:
-    default: "14"
-    description: "NodeJS version to be used for the test run"
-    required: false
   KEPTN_API_ENDPOINT:
     default: ""
     description: "Keptn API endpoint to be used for test run"
@@ -17,10 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps: 
-    - name: Install Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{inputs.NODE_VERSION}}
     - name: Install tsc
       shell: bash
       run: npm install typescript@4.0.2

--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -12,7 +12,11 @@ inputs:
     required: true
 runs:
   using: "composite"
-  steps: 
+  steps:
+    - name: Install Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
     - name: Install tsc
       shell: bash
       run: npm install typescript@4.0.2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,13 +28,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
       - name: Unit tests
         uses: ./.github/actions/unit-tests
         with:
           KEPTN_API_ENDPOINT: http://somekeptninstall.mock/api
           KEPTN_API_TOKEN: somefancysupersecrettoken
-

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
       - name: Unit tests
         uses: ./.github/actions/unit-tests
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   prepare_ci_run:
     name: Prepare CI Run
-    uses: keptn/gh-automation/.github/workflows/prepare-ci.yml@v1.4.0
+    uses: keptn/gh-automation/.github/workflows/prepare-ci.yml@v1.5.1
 
   ############################################################################
   # Unit tests                                                               #

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,40 @@
+name: Create Pre-Release
+on:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Unit tests
+        uses: ./.github/actions/unit-tests
+
+  pre-release:
+    needs: test
+    name: Pre-Release
+    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.5.0
+
+  package-dev-extension:
+    needs: [pre-release]
+    name: "Package DEV extension"
+    runs-on: ubuntu-20.04
+    env:
+      VERSION: ${{ needs.pre-release.outputs.RELEASE_TAG }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PRE_RELEASE_SEPARATOR: "next"
+      AZDO_PUBTOKEN: ""
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - run: |
+          npm install
+          # transform x.y.z-next.{prerelease} into x.y.z.{prerelease} for packaging and publishing the extension as per Microsoft requirements
+          export AZDO_EXT_VERSION=$(echo ${VERSION} | sed 's/-${{env.PRE_RELEASE_SEPARATOR}}\(\.[[:digit:]]\+\)$/\1/g')
+          npm run package-dev
+          gh release upload "${VERSION}" *.vsix
+          #npm run publish-dev

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -7,10 +7,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
       - name: Unit tests
         uses: ./.github/actions/unit-tests
 
@@ -27,14 +23,11 @@ jobs:
       VERSION: ${{ needs.pre-release.outputs.RELEASE_TAG }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PRE_RELEASE_SEPARATOR: "next"
-      AZDO_PUBTOKEN: ""
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
       - run: |
           npm install
           # transform x.y.z-next.{prerelease} into x.y.z.{prerelease} for packaging and publishing the extension as per Microsoft requirements
-          export AZDO_EXT_VERSION=$(echo ${VERSION} | sed 's/-${{env.PRE_RELEASE_SEPARATOR}}\(\.[[:digit:]]\+\)$/\1/g')
-          npm run package-dev
+          AZDO_EXT_VERSION=$(echo ${VERSION} | sed 's/-${{env.PRE_RELEASE_SEPARATOR}}\(\.[[:digit:]]\+\)$/\1/g') npm run package-dev
           gh release upload "${VERSION}" *.vsix
-          #npm run publish-dev

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -17,7 +17,7 @@ jobs:
   pre-release:
     needs: test
     name: Pre-Release
-    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.5.0
+    uses: keptn/gh-automation/.github/workflows/pre-release-integration.yml@v1.5.1
 
   package-dev-extension:
     needs: [pre-release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
   release:
     needs: test
     name: Release
-    uses: keptn/gh-automation/.github/workflows/release-integration.yml@v1.5.0
+    uses: keptn/gh-automation/.github/workflows/release-integration.yml@v1.5.1
 
   package-dev-extension:
     needs: [release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Create Release
+on:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Unit tests
+        uses: ./.github/actions/unit-tests
+
+  release:
+    needs: test
+    name: Release
+    uses: keptn/gh-automation/.github/workflows/release-integration.yml@v1.5.0
+
+  package-dev-extension:
+    needs: [release]
+    name: "Package PUBLIC extension"
+    runs-on: ubuntu-20.04
+    env:
+      VERSION: ${{ needs.release.outputs.RELEASE_TAG }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AZDO_PUBTOKEN: ""
+      AZDO_EXT_VERSION: ${{ needs.release.outputs.RELEASE_TAG }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - run: |
+          npm install
+          npm run package
+          gh release upload "${VERSION}" *.vsix
+          # npm run publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
       - name: Unit tests
         uses: ./.github/actions/unit-tests
 
@@ -26,7 +22,6 @@ jobs:
     env:
       VERSION: ${{ needs.release.outputs.RELEASE_TAG }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AZDO_PUBTOKEN: ""
       AZDO_EXT_VERSION: ${{ needs.release.outputs.RELEASE_TAG }}
     steps:
       - name: Check out repository
@@ -35,4 +30,3 @@ jobs:
           npm install
           npm run package
           gh release upload "${VERSION}" *.vsix
-          # npm run publish

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 jobs:
   validate:
-    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@main
+    uses: keptn/gh-automation/.github/workflows/validate-semantic-pr.yml@v1.5.1
     with:
       # Configure which scopes are allowed.
       scopes: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keptn-integration",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "description": "Integration of Keptn within your build.",
   "scripts": {
     "clean": "rimraf ./*.vsix ./dist",


### PR DESCRIPTION
Adds pre-release and release workflow.
Packaged extension is added to both prerelease and release as an asset.
Prerelease workflow will package the `dev` extension while releases will package the `public` extension
Extension can be published directly using `npm run publish(-dev)` (the command is already added in the workflow but it's commented) once a PAT is available for publishing and is set in the `AZDO_PUBTOKEN` env variable.