### PR TITLE
docs: Mention AZDO_EXT_VERSION in the build documentation

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -50,7 +50,7 @@ npm run test-addr
 
 In the main directory, run
 ```
-npm run package-dev
+AZDO_EXT_VERSION=<your version> npm run package-dev
 ```
 **Note**: See [manifest.js](manifest.js) section for configuration
 
@@ -60,7 +60,7 @@ npm run package-dev
 
 In the main directory, run
 ```
-npm run package
+AZDO_EXT_VERSION=<your version> npm run package
 ```
 **Note**: See [manifest.js](manifest.js) section for configuration
 
@@ -74,9 +74,9 @@ the extension ( private and public respectively) in a single command provided th
 a personal access token is passed in env variable `AZDO_PUBTOKEN`, so:
 - To publish a private version of the extension
 ```
-AZDO_PUBTOKEN=<your token goes here> npm run publish-dev
+AZDO_EXT_VERSION=<your version> AZDO_PUBTOKEN=<your token goes here> npm run publish-dev
 ```
 - To publish a public version fo the extension
 ```
-AZDO_PUBTOKEN=<your token goes here> npm run publish
+AZDO_EXT_VERSION=<your version> AZDO_PUBTOKEN=<your token goes here> npm run publish
 ```

--- a/manifest.js
+++ b/manifest.js
@@ -42,7 +42,12 @@ function addPathToFileContributions(
 module.exports = (env) => {
   let [idPostfix, namePostfix, isPublic] =
     env.mode == "development" ? ["-dev", " [DEV]", false] : ["", "", true];
-  let version = env.version != undefined ? env.version : "1.5.0";
+
+  if (!env.version) {
+    throw new Error("No version given, please set the enviornment variable AZDO_EXT_VERSION to your desired version!")
+  }
+
+  let version = env.version;
 
   let manifest = {
     manifestVersion: 1,

--- a/manifest.js
+++ b/manifest.js
@@ -44,7 +44,7 @@ module.exports = (env) => {
     env.mode == "development" ? ["-dev", " [DEV]", false] : ["", "", true];
 
   if (!env.version) {
-    throw new Error("No version given, please set the enviornment variable AZDO_EXT_VERSION to your desired version!")
+    throw new Error("No version found in environment, please check your environment definition!")
   }
 
   let version = env.version;


### PR DESCRIPTION
## This PR
* Mentions the `AZDO_EXT_VERSION` in the documentation which is needed for the build process
* Building without specifying `AZDO_EXT_VERSION` will result in an easier to understand error. 